### PR TITLE
図面画像情報を送るときに現場IDを添付するのを廃止

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   images: {
     remotePatterns: [
+      new URL('http://localhost:8080/**'),
       {
         protocol: 'https',
         hostname: 'blueprints-management-bucket.s3.ap-northeast-1.amazonaws.com',

--- a/src/app/actions/architecturalAction.ts
+++ b/src/app/actions/architecturalAction.ts
@@ -6,13 +6,18 @@ interface FormState {
   error: string;
 }
 
-export const addArchitecturalDrawing = async(blueprintId: string, pathName: string, createdAtList: string[], formState: FormState, formData: FormData) => {
+
+export const addArchitecturalDrawing = async(id: string, blueprintId: string, pathName: string, createdAtList: string[], formState: FormState, formData: FormData) => {
+
   const rawFormData = Object.fromEntries(formData);
   const createdAt = rawFormData.createdAt as string;
+  const siteId = id;
+
   if(createdAtList.includes(createdAt)) {
     return {error: "選択した日付の図面が存在します"}
   }
 
+  formData.append("siteId", siteId);
   formData.append("blueprintId", blueprintId);
 
   const response = await fetch(`${process.env.ENDPOINT}/architecturalDrawings`, {

--- a/src/app/actions/architecturalAction.ts
+++ b/src/app/actions/architecturalAction.ts
@@ -7,17 +7,16 @@ interface FormState {
 }
 
 
-export const addArchitecturalDrawing = async(id: string, blueprintId: string, pathName: string, createdAtList: string[], formState: FormState, formData: FormData) => {
+export const addArchitecturalDrawing = async(blueprintId: string, pathName: string, createdAtList: string[], formState: FormState, formData: FormData) => {
 
   const rawFormData = Object.fromEntries(formData);
   const createdAt = rawFormData.createdAt as string;
-  const siteId = id;
+
 
   if(createdAtList.includes(createdAt)) {
     return {error: "選択した日付の図面が存在します"}
   }
 
-  formData.append("siteId", siteId);
   formData.append("blueprintId", blueprintId);
 
   const response = await fetch(`${process.env.ENDPOINT}/architecturalDrawings`, {

--- a/src/components/Management/Blueprint/BlueprintInfo/Modal/UpdateBlueprintModal.tsx
+++ b/src/components/Management/Blueprint/BlueprintInfo/Modal/UpdateBlueprintModal.tsx
@@ -11,10 +11,10 @@ export interface PropsType {
 
 const UpdateBlueprintModal = ({createdAtList, isOpenUpdateModal, setIsOpenUpdateModal}: PropsType) => {
 
-  const {id, blueprintId} = useParams() as {id: string, blueprintId: string};
+  const {blueprintId} = useParams() as {blueprintId: string};
   const pathName = usePathname();
 
-  const addArchitecturalDrawingWithParams = addArchitecturalDrawing.bind(null, id, blueprintId, pathName, createdAtList);
+  const addArchitecturalDrawingWithParams = addArchitecturalDrawing.bind(null, blueprintId, pathName, createdAtList);
 
   const initialState = {error: ""}
   const [state, formAction, isPending] = useActionState(addArchitecturalDrawingWithParams, initialState);

--- a/src/components/Management/Blueprint/BlueprintInfo/Modal/UpdateBlueprintModal.tsx
+++ b/src/components/Management/Blueprint/BlueprintInfo/Modal/UpdateBlueprintModal.tsx
@@ -11,10 +11,10 @@ export interface PropsType {
 
 const UpdateBlueprintModal = ({createdAtList, isOpenUpdateModal, setIsOpenUpdateModal}: PropsType) => {
 
-  const {blueprintId}: {blueprintId: string} = useParams();
+  const {id, blueprintId} = useParams() as {id: string, blueprintId: string};
   const pathName = usePathname();
 
-  const addArchitecturalDrawingWithParams = addArchitecturalDrawing.bind(null, blueprintId, pathName, createdAtList);
+  const addArchitecturalDrawingWithParams = addArchitecturalDrawing.bind(null, id, blueprintId, pathName, createdAtList);
 
   const initialState = {error: ""}
   const [state, formAction, isPending] = useActionState(addArchitecturalDrawingWithParams, initialState);


### PR DESCRIPTION
# 変更内容
図面画像情報のファイルパスを図面IDのみで管理するため、不要な現場IDを添付するのを廃止