### PR TITLE
備考欄の情報を改行できるように変更

### DIFF
--- a/src/components/Management/Site/SiteInfo/SiteInfo.tsx
+++ b/src/components/Management/Site/SiteInfo/SiteInfo.tsx
@@ -26,7 +26,7 @@ const SiteInfo = async({id}: Props) => {
           <ShareButton id={id} name={name}/>
         </div>
         <p className="text-4xl mb-4">{address}</p>
-        <p className="text-2xl">{remark}</p>
+        <p className="text-2xl whitespace-pre-line">{remark}</p>
       </div>
       
       <EditOrDeleteModal siteInfo={siteInfo}/>


### PR DESCRIPTION
# 変更点

備考欄の改行コードが反映されなかったため、
cssにwhitespace-pre-lineを追加して改行コードを読み込めるように変更しました。